### PR TITLE
fix: update Dockerfile to output directly, and fix wrong path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,3 @@ COPY nerdaxe_hashrate_benchmark.py .
 
 # Set the entrypoint
 ENTRYPOINT ["python", "-u", "nerdaxe_hashrate_benchmark.py"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY bitaxe_hashrate_benchmark.py .
 
 # Set the entrypoint
-ENTRYPOINT ["python", "bitaxe_hashrate_benchmark.py"]
+ENTRYPOINT ["python", "-u", "nerdaxe_hashrate_benchmark.py"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the script
-COPY bitaxe_hashrate_benchmark.py .
+COPY nerdaxe_hashrate_benchmark.py .
 
 # Set the entrypoint
 ENTRYPOINT ["python", "-u", "nerdaxe_hashrate_benchmark.py"]
+
 


### PR DESCRIPTION
Trying to run the `Dockerfile` but that doesn't work at the moment. This also fixes this issue: https://github.com/SerpentXSF/NerdQAxe_hashrate_benchmark/issues/2

I also added the `-u` for direct output 

```
-u 
unbuffered binary stdout and stderr; also PYTHONUNBUFFERED=x see man page for details on internal buffering relating to '-u'
```